### PR TITLE
Fixed missing package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     url='https://github.com/yeasy/hyperledger-py/',
     packages=[
         'hyperledger', 'hyperledger.api', 'hyperledger.auth',
-        'hyperledger.utils',
+        'hyperledger.ssladapter', 'hyperledger.utils',
     ],
     platforms='any',
     install_requires=requirements,


### PR DESCRIPTION
Hi, your release of version [0.1.3](https://pypi.python.org/pypi/hyperledger/0.1.3) is broken with a missing package.
